### PR TITLE
VIP Jetpack: Remove Jetpack SSO as mandatory

### DIFF
--- a/jetpack-mandatory.php
+++ b/jetpack-mandatory.php
@@ -22,7 +22,6 @@ class WPCOM_VIP_Jetpack_Mandatory {
 		'monitor',
 		'photon',
 		'protect',
-		'sso',
 		'stats',
 		'vaultpress',
 	);


### PR DESCRIPTION
**Work in progress: DO NOT MERGE**

We have clients using their own SSO service, and
having Jetpack in the middle of this can complicate
the situation.
