### PR TITLE
Add filter to use the site's domain for Photon

### DIFF
--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -10,3 +10,10 @@
  */
 
 require_once( __DIR__ . '/jetpack-mandatory.php' );
+
+/**
+ * On VIP Go, we always want to use the Go Photon service, instead of WordPress.com's
+ */
+add_filter( 'jetpack_photon_domain', function( $domain, $image_url ) {
+	return home_url();
+}, 2, 9999 );


### PR DESCRIPTION
Will cause it to use the Go Photon service, instead of WP.com, which
will:

1) Be faster
2) Work before sites are live
3) Be awesome