### PR TITLE
By default, Photon won't resize an SSL image

### DIFF
--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -17,3 +17,9 @@ require_once( __DIR__ . '/jetpack-mandatory.php' );
 add_filter( 'jetpack_photon_domain', function( $domain, $image_url ) {
 	return home_url();
 }, 2, 9999 );
+
+/**
+ * Front-end SSL is support on VIP Go and in our file service,
+ * and Jetpack's Photon module should respect that.
+ */
+add_filter( 'jetpack_photon_reject_https', '__return_false' );


### PR DESCRIPTION
As noted in #5, by default Photon ignores images served over https. Fortunately the module provides a filter to bypass this restriction.

This complements the change from #9.