### PR TITLE
Jetpack 3.9: disable Sitemaps in favor of `msm-sitemap`

### DIFF
--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -10,6 +10,11 @@
  */
 
 /**
+ * Enable VIP modules required as part of the platform
+ */
+require_once( __DIR__ . '/jetpack-mandatory.php' );
+
+/**
  * Remove certain modules from the list of those that can be activated
  * Blocks access to certain functionality that isn't compatible with the platform.
  */
@@ -18,11 +23,6 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 
 	return $modules;
 }, 999 );
-
-/**
- * Enable VIP modules required as part of the platform
- */
-require_once( __DIR__ . '/jetpack-mandatory.php' );
 
 /**
  * On VIP Go, we always want to use the Go Photon service, instead of WordPress.com's

--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -9,6 +9,19 @@
  * License: GPL2+
  */
 
+/**
+ * Remove certain modules from the list of those that can be activated
+ * Blocks access to certain functionality that isn't compatible with the platform.
+ */
+add_filter( 'jetpack_get_available_modules', function( $modules ) {
+	unset( $modules['sitemaps'] ); // Duplicates msm-sitemaps and doesn't scale for our client's needs (https://github.com/Automattic/jetpack/issues/3314)
+
+	return $modules;
+}, 999 );
+
+/**
+ * Enable VIP modules required as part of the platform
+ */
 require_once( __DIR__ . '/jetpack-mandatory.php' );
 
 /**


### PR DESCRIPTION
Until https://github.com/Automattic/jetpack/issues/3314 is addressed, Jetpack's implementation won't suit our client's needs. For now, we prefer `msm-sitemap` and won't support Jetpack's implementation.