### PR TITLE
Remove Photon

### DIFF
--- a/jetpack-mandatory.php
+++ b/jetpack-mandatory.php
@@ -19,7 +19,6 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	protected $mandatory_modules = array(
 		'manage',
 		'monitor',
-		'photon',
 		'protect',
 		'sso',
 		'stats',

--- a/jetpack-misc.php
+++ b/jetpack-misc.php
@@ -12,30 +12,7 @@
  */
 add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	unset( $modules['sitemaps'] ); // Duplicates msm-sitemaps and doesn't scale for our client's needs (https://github.com/Automattic/jetpack/issues/3314)
+	unset( $modules['photon'] );
 
 	return $modules;
 }, 999 );
-
-/**
- * On VIP Go, we always want to use the Go Photon service, instead of WordPress.com's
- */
-add_filter( 'jetpack_photon_domain', function( $domain, $image_url ) {
-	/**
-	 * Filter whether this site replaces Jetpack Photon
-	 * with the VIP Go Files Service.
-	 *
-	 * @param bool  $enable  If false, Jetpack Photon is used instead of the VIP Go Files Service
-	 */
-	if ( ! apply_filters( 'wpcom_vip_enable_go_photon', true ) ) {
-		return $domain;
-	}
-
-	// only apply to photon images
-	if ( preg_match( '|^https?://i[0-9]+.wp.com$|', $domain ) ) {
-		return home_url();
-	}
-
-	// return all other images
-	$url = wp_parse_url( $image_url );
-	return $url['host'];
-}, 2, 9999 );


### PR DESCRIPTION
Photon is not intended to be used on VIP Go. The way we're using it
breaks external images.

Instead, we will manually use srcset with the VIP Go files service.

Note: jetpack_photon_url will stil work even if Photon is not enabled.

See also: #16 