### PR TITLE
Lock force 2fa behind a constant

### DIFF
--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -18,8 +18,6 @@ require_once( __DIR__ . '/jetpack-mandatory.php' );
  * Remove certain modules from the list of those that can be activated
  * Blocks access to certain functionality that isn't compatible with the platform.
  */
-require_once( __DIR__ . '/jetpack-force-2fa/jetpack-force-2fa.php' );
-
 add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	unset( $modules['photon'] );
 	unset( $modules['site-icon'] );
@@ -28,4 +26,7 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	return $modules;
 }, 999 );
 
-add_filter( 'jetpack_force_2fa_dependency_notice', '__return_false' );
+if ( defined( 'WPCOM_VIP_FORCE_JETPACK_2FA' ) && true === WPCOM_VIP_FORCE_JETPACK_2FA ) {
+	add_filter( 'jetpack_force_2fa_dependency_notice', '__return_false' );
+	require_once( __DIR__ . '/jetpack-force-2fa/jetpack-force-2fa.php' );
+}


### PR DESCRIPTION
So we can selectively enable for now while we test/roll out the functionality.

To enable, add `define( 'WPCOM_VIP_FORCE_JETPACK_2FA', true );` to config.