### PR TITLE
Bump jetpack-force-2fa

### DIFF
--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -26,5 +26,8 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 	return $modules;
 }, 999 );
 
+/**
+ * Load Jetpack Force 2fa
+ */
 add_filter( 'jetpack_force_2fa_dependency_notice', '__return_false' );
 require_once( __DIR__ . '/jetpack-force-2fa/jetpack-force-2fa.php' );


### PR DESCRIPTION
Adds a better error message when forcing WP.com login for users.