### PR TITLE
Stop loading jetpack-force-2fa on all sites.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "jetpack-force-2fa"]
-	path = jetpack-force-2fa
-	url = git@github.com:Automattic/jetpack-force-2fa.git

--- a/jetpack-mandatory.php
+++ b/jetpack-mandatory.php
@@ -19,7 +19,7 @@ class WPCOM_VIP_Jetpack_Mandatory {
 	protected $mandatory_modules = array(
 		'manage',
 		'monitor',
-		// 'sso', // Disabled while we roll out force-2fa
+		// 'sso',
 		'stats',
 		'vaultpress',
 	);

--- a/vip-jetpack.php
+++ b/vip-jetpack.php
@@ -25,9 +25,3 @@ add_filter( 'jetpack_get_available_modules', function( $modules ) {
 
 	return $modules;
 }, 999 );
-
-/**
- * Load Jetpack Force 2fa
- */
-add_filter( 'jetpack_force_2fa_dependency_notice', '__return_false' );
-require_once( __DIR__ . '/jetpack-force-2fa/jetpack-force-2fa.php' );


### PR DESCRIPTION
We'll move it to shared-plugins so clients can use it if they want, but
not required.